### PR TITLE
Keep continuation lines without thread + make RegEx compatible for seed nodes

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -22,7 +22,7 @@ extract.add_argument(
 args = parser.parse_args()
 
 # Define patterns for regex.
-PATTERN_NODE_NAME = r"model\.[^\s]+"
+PATTERN_NODE_NAME = r'[a-zA-Z_]+\.[^\s"]+'
 PATTERN_THREAD_NUMBER = r"Thread-(\d+)"
 
 


### PR DESCRIPTION
Not sure if you're even interested in keeping the continuation log lines without thread numbers but I think it's super helpful for debugging when you can also see the query statements, etc..
Also changed the RegEx pattern as described [here](https://github.com/jeremyyeo/ddbt/issues/1).

Lmk what you think (: